### PR TITLE
Fix for Tito

### DIFF
--- a/common/history/characters/rulers.txt
+++ b/common/history/characters/rulers.txt
@@ -352,7 +352,7 @@ CHARACTERS = {
 			birth_date = 1892.5.7
 			interest_group = ig_rural_folk
 			ideology = ideology_autocratic
-			culture = cu:serb
+			culture = cu:croat
 			traits = {
 				charismatic
 				imperious


### PR DESCRIPTION
Tito was born to a Croat father and Slovene mother in (present day) Croatia, and grew up as such.


When and if Yugoslav gets added as a culture, that would be a better match given his aspirations for creating a pan-Slavic state. However, until then I think marking him as Serb when his culture and upbringing was not Serb is a bit odd. I am not sure how that slipped through.