### PR TITLE
Update 00_canals.txt

### DIFF
--- a/common/canals/00_canals.txt
+++ b/common/canals/00_canals.txt
@@ -1,31 +1,39 @@
 ﻿canal_suez = {
-	texture = "gfx/interface/icons/building_icons/suez_canal.dds"
+    texture = "gfx/interface/icons/building_icons/suez_canal.dds"
 
-	possible = {
-		#has_technology_researched = colonization
-		owns_treaty_port_in = STATE_SINAI
-		custom_tooltip = {
-			text = suez_survey_complete_tooltip
-			has_variable = suez_survey_complete
-		}
-		
-	}
+    possible = {
+        # Uncomment if you want a specific tech requirement:
+        # has_technology_researched = colonization
 
-	state_region = STATE_SINAI
+        # Must own a treaty port in Sinai to build:
+        owns_treaty_port_in = STATE_SINAI
+
+        custom_tooltip = {
+            text = suez_survey_complete_tooltip
+            has_variable = suez_survey_complete
+        }
+    }
+
+    # The canal is specifically tied to this state region:
+    state_region = STATE_SINAI
 }
 
 canal_panama = {
-	texture = "gfx/interface/icons/building_icons/panama_canal.dds"
+    texture = "gfx/interface/icons/building_icons/panama_canal.dds"
 
-	possible = {
-		#has_technology_researched = civilizing_mission
-		owns_treaty_port_in = STATE_PANAMA
+    possible = {
+        # Uncomment if you want a specific tech requirement:
+        # has_technology_researched = civilizing_mission
 
-		custom_tooltip = {
-			text = panama_survey_complete_tooltip
-			has_variable = panama_survey_complete
-		}
-	}
+        # Must own a treaty port in Panama to build:
+        owns_treaty_port_in = STATE_PANAMA
 
-	state_region = STATE_PANAMA
+        custom_tooltip = {
+            text = panama_survey_complete_tooltip
+            has_variable = panama_survey_complete
+        }
+    }
+
+    # The canal is specifically tied to this state region:
+    state_region = STATE_PANAMA
 }


### PR DESCRIPTION
Below is an updated and enhanced version of your canal definition code. Key improvements include:

Consistent Indentation & Formatting
Optional Comments (for potential technology requirements) Clearer Structure (grouping of possible conditions) Feel free to remove or uncomment any lines that best match your mod’s logic or requirements

Technology Requirements: The commented lines (e.g. has_technology_researched) can be re-enabled if you want a specific technology prerequisite. Ownership Conditions: If you require complete state ownership instead of just a treaty port, change owns_treaty_port_in to your desired condition. Tooltips: The custom_tooltip block ensures a localized message is shown if the variable (e.g. suez_survey_complete) is not set. Adapt this to your mod’s event logic. With these improvements, your canal definitions are more organized, readable, and easier to maintain.