### PR TITLE
Small Bureacracy, Advanced Military Equipment, AI Tweaks

### DIFF
--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -1,4 +1,4 @@
-﻿ This is a special strategy that sets the default values for different AI scores
+﻿# This is a special strategy that sets the default values for different AI scores
 # All AIs always load data from this strategy, which can then be either added to or overridden by data from its other strategies
 
 ai_strategy_default = {

--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -1293,21 +1293,21 @@ ai_strategy_default = {
 
 		add = {
 			value = investment_pool_income
-			divide = 100000 # 1 construction output per this much into the investment pool				
+			divide = 10000 # 1 construction output per this much into the investment pool				
 		}
 		
 		add = {
 			value = investment_pool
-			divide = 1000000 # 1 construction output per this much into the investment pool				
+			divide = 100000 # 1 construction output per this much into the investment pool				
 		}
 		
 		add = {
 			value = income
 			
-			divide = 50000 # 1 construction output per this much income
+			divide = 10000 # 1 construction output per this much income
 
 			min = 0
-			max = 200 # Above a certain point more government income isn't going to lead to more AI government construction
+			max = 2000 # Above a certain point more government income isn't going to lead to more AI government construction
 		}
 
 		add = {
@@ -1357,7 +1357,7 @@ ai_strategy_default = {
 		}		
 
 		min = 10
-		max = 1000
+		max = 10000
 		
 	}
 	
@@ -1810,7 +1810,7 @@ ai_strategy_default = {
 				country_rank >= rank_value:great_power
 			}
 		}
-		ammunition = {
+		advanced_weaponry = {
 			stance = wants_high_supply
 			trigger = {
 				country_rank >= rank_value:great_power

--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -1,4 +1,4 @@
-﻿# This is a special strategy that sets the default values for different AI scores
+﻿ This is a special strategy that sets the default values for different AI scores
 # All AIs always load data from this strategy, which can then be either added to or overridden by data from its other strategies
 
 ai_strategy_default = {
@@ -1376,23 +1376,31 @@ ai_strategy_default = {
 	
 		add = {
 			value = cached_ai_incorporated_population
-			divide = 250000 # 1 level of barracks per 250k incorporated population	
+			divide = 250000 # 1 level of barracks per 250k incorporated population
+
+			max = 100	
 		}
 
 		add = {
 			value = cached_ai_unincorporated_population
 			divide = 1000000 # 1 level of barracks per 1 million unincorporated population	
+
+			max = 100
 		}
-		
+
 		# Coastal population reduces spending on army as that spending is needed for navy too
 		subtract = {
 			value = cached_ai_incorporated_coastal_population
 			divide = 1000000 
+
+			max = 100
 		}		
 		
 		subtract = {
 			value = cached_ai_unincorporated_coastal_population
 			divide = 4000000 
+
+			max = 100
 		}
 
 		save_temporary_value_as = pre_overseas_empire_value
@@ -1426,8 +1434,17 @@ ai_strategy_default = {
 			}	
 		}
 		
-		max = 200 # No more than 200 from population & rank
+		max = 100 # No more than 100 from population & rank
 		
+		add = {
+			value = income
+			
+			divide = 10000 # 1 barraks per this much income
+
+			min = 0
+			max = 1500 # Above a certain point more government income isn't going to lead to more AI armies
+		}
+
 		# More advanced standing armies are expensive and should be smaller relative to population
 		if = {
 			limit = { has_technology_researched = tech_military_ground_forces_1 }
@@ -1480,19 +1497,19 @@ ai_strategy_default = {
 		# Extra army size from rank
 		if = {
 			limit = { country_rank = rank_value:super_power }
-			add = 400
-		}
-		if = {
-			limit = { country_rank = rank_value:great_power }
-			add = 200
-		}
-		if = {
-			limit = { country_rank = rank_value:major_power }
 			add = 100
 		}
 		if = {
-			limit = { country_rank = rank_value:minor_power }
+			limit = { country_rank = rank_value:great_power }
 			add = 50
+		}
+		if = {
+			limit = { country_rank = rank_value:major_power }
+			add = 25
+		}
+		if = {
+			limit = { country_rank = rank_value:minor_power }
+			add = 10
 		}
 		
 		#From government type
@@ -1522,23 +1539,26 @@ ai_strategy_default = {
 		add = {
 			value = cached_ai_incorporated_coastal_population
 			divide = 500000 
+
 		}
 
 		# 1 level of naval base per 2 million coastal unincorporated population					
 		add = {
 			value = cached_ai_unincorporated_coastal_population
 			divide = 2000000 
+
 		}
 
 		# 1 level of naval base per 10 million population in direct overseas subjects	
 		add = {
 			value = cached_ai_overseas_subject_population
 			divide = 10000000 
-		}	
+
+		}	 
 
 		max = 100 # No more than 100 from population		
 
-		# 1 level of naval base per 5k income, multiplied by relative incorporated coastal population to total incorporated population
+		# 1 level of naval base per 25k income, multiplied by relative incorporated coastal population to total incorporated population
 		if = {
 			limit = {
 				cached_ai_incorporated_population > 0
@@ -1548,22 +1568,24 @@ ai_strategy_default = {
 				value = income
 				divide = cached_ai_incorporated_population
 				multiply = cached_ai_incorporated_coastal_population
-				divide = 5000
+				divide = 25000
+
+				max = 500
 			}	
 		}
 	
 		# GPs and MPs should want to maintain a bit of a navy
 		if = {
 			limit = { country_rank = rank_value:super_power }
-			add = 50
+			add = 25
 		}
 		else_if = {
 			limit = { country_rank = rank_value:great_power }
-			add = 25		
+			add = 10		
 		}
 		else_if = {
 			limit = { country_rank = rank_value:major_power }
-			add = 10
+			add = 5
 		}
 		
 		# More advanced navies are expensive and should be smaller relative to population

--- a/common/history/global/00_global.txt
+++ b/common/history/global/00_global.txt
@@ -338,7 +338,7 @@ GLOBAL = {
 			limit = { is_incorporated = yes }
 			add_modifier = {
 				name = starting_historical_sol
-				years = 10
+				years = 20
 				is_decaying = yes
 			}
 		}

--- a/common/production_methods/bg_government_1_goods.txt
+++ b/common/production_methods/bg_government_1_goods.txt
@@ -9,7 +9,7 @@ pm_bureaucracy_government_1 = {
 	
 	country_modifiers = {
 		workforce_scaled = {
-			country_bureaucracy_add = 100
+			country_bureaucracy_add = 150
 			state_tax_capacity_add = 10
 		}
 	}
@@ -29,7 +29,7 @@ pm_bureaucracy_government_1 = {
 			#goods_output_real_estate_add = 0.1
 		}
 		level_scaled = { 
-			building_employment_bureaucrats_add = 5000
+			building_employment_bureaucrats_add = 3000
 		}
 	}
 	
@@ -67,7 +67,7 @@ pm_bureaucracy_government_2 = {
 			#goods_output_real_estate_add = 0.1
 		}
 		level_scaled = { 
-			building_employment_bureaucrats_add = 5000
+			building_employment_bureaucrats_add = 4000
 		}
 	}
 	
@@ -105,7 +105,7 @@ pm_bureaucracy_government_3 = {
 			#goods_output_real_estate_add = 0.1
 		}
 		level_scaled = { 
-			building_employment_bureaucrats_add = 5000
+			building_employment_bureaucrats_add = 6000
 		}
 	}
 	
@@ -144,7 +144,7 @@ pm_bureaucracy_government_4 = {
 			#goods_output_real_estate_add = 0.1
 		}
 		level_scaled = { 
-			building_employment_bureaucrats_add = 5000
+			building_employment_bureaucrats_add = 8000
 		}
 	}
 	
@@ -183,7 +183,7 @@ pm_bureaucracy_government_5 = {
 			#goods_output_real_estate_add = 0.1
 		}
 		level_scaled = { 
-			building_employment_bureaucrats_add = 5000
+			building_employment_bureaucrats_add = 10000
 		}
 	}
 	
@@ -193,11 +193,24 @@ pm_bureaucracy_government_5 = {
 
 pm_essential_services_government_0 = {
 	texture = "gfx/interface/icons/production_method_icons/wound_dressing.dds"
-	
+		
+		disallowing_laws = {
+		#law_no_social_social_security
+		law_low_social_security
+		law_medium_social_security
+		law_high_social_security
+	}
 }
 
 pm_essential_services_government_1 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
+
+		disallowing_laws = {
+		law_no_social_social_security
+		#law_low_social_security
+		law_medium_social_security
+		law_high_social_security
+	}
 
 	state_modifiers = {
 		unscaled = {
@@ -237,6 +250,14 @@ pm_essential_services_government_1 = {
 pm_essential_services_government_2 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
 
+		disallowing_laws = {
+		law_no_social_social_security
+		#law_low_social_security
+		#law_medium_social_security
+		#law_high_social_security
+	}
+
+
 	state_modifiers = {
 		unscaled = {
 			state_pop_qualifications_mult = 0.03
@@ -274,6 +295,13 @@ pm_essential_services_government_2 = {
 
 pm_essential_services_government_3 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
+
+		disallowing_laws = {
+		law_no_social_social_security
+		law_low_social_security
+		#law_medium_social_security
+		#law_high_social_security
+	}
 
 	state_modifiers = {
 		unscaled = {
@@ -315,10 +343,24 @@ pm_essential_services_government_3 = {
 pm_security_services_government_0 = {
 	texture = "gfx/interface/icons/production_method_icons/no_specialists.dds"
 	
+		disallowing_laws = {
+		#law_lenient_policing
+		law_balanced_policing
+		law_strict_policing
+		law_draconian_policing
+	}
+
 }
 
 pm_security_services_government_1 = {
 	texture = "gfx/interface/icons/production_method_icons/cavalry.dds"
+
+		disallowing_laws = {
+		#law_lenient_policing
+		#law_balanced_policing
+		law_strict_policing
+		law_draconian_policing
+	}
 	
 	building_modifiers = {
 		workforce_scaled = {
@@ -342,6 +384,13 @@ pm_security_services_government_1 = {
 
 pm_security_services_government_2 = {
 	texture = "gfx/interface/icons/production_method_icons/irregular_infantry.dds"
+
+		disallowing_laws = {
+		law_lenient_policing
+		#law_balanced_policing
+		#law_strict_policing
+		law_draconian_policing
+	}
 	
 	building_modifiers = {
 		workforce_scaled = { 
@@ -365,6 +414,13 @@ pm_security_services_government_2 = {
 
 pm_security_services_government_3 = {
 	texture = "gfx/interface/icons/production_method_icons/machine_gunners.dds"
+
+		disallowing_laws = {
+		law_lenient_policing
+		law_balanced_policing
+		#law_strict_policing
+		#law_draconian_policing
+	}
 	
 	building_modifiers = {
 		workforce_scaled = { 
@@ -388,6 +444,13 @@ pm_security_services_government_3 = {
 
 pm_security_services_government_4 = {
 	texture = "gfx/interface/icons/production_method_icons/flamethrower_company.dds"
+
+		disallowing_laws = {
+		law_lenient_policing
+		law_balanced_policing
+		law_strict_policing
+		#law_draconian_policing
+	}
 	
 	building_modifiers = {
 		workforce_scaled = { 

--- a/common/production_methods/bg_government_1_goods.txt
+++ b/common/production_methods/bg_government_1_goods.txt
@@ -193,21 +193,21 @@ pm_bureaucracy_government_5 = {
 
 pm_essential_services_government_0 = {
 	texture = "gfx/interface/icons/production_method_icons/wound_dressing.dds"
-		
-		disallowing_laws = {
-		#law_no_social_social_security
-		law_low_social_security
-		law_medium_social_security
-		law_high_social_security
+	
+	unlocking_laws = {
+		law_no_social_social_security
+		#law_low_social_security
+		#law_medium_social_security
+		#law_high_social_security
 	}
 }
 
 pm_essential_services_government_1 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
 
-		disallowing_laws = {
-		law_no_social_social_security
-		#law_low_social_security
+	unlocking_laws = {
+		#law_no_social_social_security
+		law_low_social_security
 		law_medium_social_security
 		law_high_social_security
 	}
@@ -250,11 +250,11 @@ pm_essential_services_government_1 = {
 pm_essential_services_government_2 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
 
-		disallowing_laws = {
-		law_no_social_social_security
+	unlocking_laws = {
+		#law_no_social_social_security
 		#law_low_social_security
-		#law_medium_social_security
-		#law_high_social_security
+		law_medium_social_security
+		law_high_social_security
 	}
 
 
@@ -296,11 +296,11 @@ pm_essential_services_government_2 = {
 pm_essential_services_government_3 = {
 	texture = "gfx/interface/icons/production_method_icons/field_hospitals.dds"
 
-		disallowing_laws = {
-		law_no_social_social_security
-		law_low_social_security
+	unlocking_laws = {
+		#law_no_social_social_security
+		#law_low_social_security
 		#law_medium_social_security
-		#law_high_social_security
+		law_high_social_security
 	}
 
 	state_modifiers = {
@@ -343,11 +343,11 @@ pm_essential_services_government_3 = {
 pm_security_services_government_0 = {
 	texture = "gfx/interface/icons/production_method_icons/no_specialists.dds"
 	
-		disallowing_laws = {
-		#law_lenient_policing
-		law_balanced_policing
-		law_strict_policing
-		law_draconian_policing
+	unlocking_laws = {
+		law_lenient_policing
+		#law_balanced_policing
+		#law_strict_policing
+		#law_draconian_policing
 	}
 
 }
@@ -355,11 +355,11 @@ pm_security_services_government_0 = {
 pm_security_services_government_1 = {
 	texture = "gfx/interface/icons/production_method_icons/cavalry.dds"
 
-		disallowing_laws = {
-		#law_lenient_policing
-		#law_balanced_policing
-		law_strict_policing
-		law_draconian_policing
+	unlocking_laws = {
+		law_lenient_policing
+		law_balanced_policing
+		#law_strict_policing
+		#law_draconian_policing
 	}
 	
 	building_modifiers = {
@@ -385,11 +385,11 @@ pm_security_services_government_1 = {
 pm_security_services_government_2 = {
 	texture = "gfx/interface/icons/production_method_icons/irregular_infantry.dds"
 
-		disallowing_laws = {
-		law_lenient_policing
-		#law_balanced_policing
-		#law_strict_policing
-		law_draconian_policing
+	unlocking_laws = {
+		#law_lenient_policing
+		law_balanced_policing
+		law_strict_policing
+		#law_draconian_policing
 	}
 	
 	building_modifiers = {
@@ -415,11 +415,11 @@ pm_security_services_government_2 = {
 pm_security_services_government_3 = {
 	texture = "gfx/interface/icons/production_method_icons/machine_gunners.dds"
 
-		disallowing_laws = {
-		law_lenient_policing
-		law_balanced_policing
-		#law_strict_policing
-		#law_draconian_policing
+	unlocking_laws = {
+		#law_lenient_policing
+		#law_balanced_policing
+		law_strict_policing
+		law_draconian_policing
 	}
 	
 	building_modifiers = {
@@ -445,11 +445,11 @@ pm_security_services_government_3 = {
 pm_security_services_government_4 = {
 	texture = "gfx/interface/icons/production_method_icons/flamethrower_company.dds"
 
-		disallowing_laws = {
-		law_lenient_policing
-		law_balanced_policing
-		law_strict_policing
-		#law_draconian_policing
+	unlocking_laws = {
+		#law_lenient_policing
+		#law_balanced_policing
+		#law_strict_policing
+		law_draconian_policing
 	}
 	
 	building_modifiers = {

--- a/common/production_methods/bg_manufacturing_1_goods.txt
+++ b/common/production_methods/bg_manufacturing_1_goods.txt
@@ -14,7 +14,7 @@ pm_ammunition_goods_manufacturing = {
 			goods_input_steel_add = 10
 			
 			# output goods
-			goods_output_ammunition_add = 100 #
+			goods_output_ammunition_add = 150 #
 		}
 
 		level_scaled = {
@@ -34,7 +34,7 @@ pm_small_arms_goods_manufacturing = {
 			goods_input_steel_add = 50
 			
 			# output goods
-			goods_output_small_arms_add = 100 #
+			goods_output_small_arms_add = 150 #
 		}
 
 		level_scaled = {
@@ -142,10 +142,10 @@ pm_advanced_weaponry_goods_manufacturing = {
 	building_modifiers = {
 		workforce_scaled = {
 			# input goods
-			goods_input_steel_add = 29
+			goods_input_steel_add = 20
 			goods_input_industrial_chemicals_add = 20
-			goods_input_circuit_boards_add = 14
-			goods_input_engines_add = 15
+			goods_input_circuit_boards_add = 10
+			goods_input_engines_add = 10
 			
 			# output goods
 			goods_output_advanced_weaponry_add = 100 #

--- a/common/scripted_effects/cwe_building_setup.txt
+++ b/common/scripted_effects/cwe_building_setup.txt
@@ -68,7 +68,7 @@ effect_starting_buildings_PRC_HND_1 = {
 	#Meat farms
 	create_building = {
 		building = "building_livestock_ranch"
-		level = 20
+		level = 5
 		reserves = 1
 		#activate_production_methods = { "pm_automation_0_building_agriculture" "pm_merchant_guilds_building_agriculture" }
 	}
@@ -271,7 +271,7 @@ effect_starting_buildings_0 = {
 	}
 	create_building = {
 		building = "building_livestock_ranch"
-		level = 5
+		level = 2
 		reserves = 1
 		#activate_production_methods = { "pm_automation_0_building_agriculture" "pm_merchant_guilds_building_agriculture" }
 	}
@@ -475,13 +475,13 @@ effect_starting_buildings_1 = {
 	
 	create_building = {
 		building = "building_fishing_wharf"
-		level = 5
+		level = 2
 		reserves = 1
 		#activate_production_methods = { "pm_automation_0_building_agriculture" "pm_merchant_guilds_building_agriculture" }
 	}
 	create_building = {
 		building = "building_livestock_ranch"
-		level = 5
+		level = 2
 		reserves = 1
 		#activate_production_methods = { "pm_automation_0_building_agriculture" "pm_merchant_guilds_building_agriculture" }
 	}

--- a/common/static_modifiers/cwe_modifiers.txt
+++ b/common/static_modifiers/cwe_modifiers.txt
@@ -315,7 +315,7 @@ starting_additional_revenue = {
 
 starting_historical_sol = {
 	icon = gfx/interface/icons/timed_modifier_icons/modifier_coins_positive.dds
-	state_standard_of_living_add = 10
+	state_standard_of_living_add = 5
 }
 
 ### Colonial System ###


### PR DESCRIPTION
Just a small one today, finishing up balancing changes, I feel really satisfied with where the game is econ wise and was able to resolve the construction sector issue without changing it fundamentally. 

Construction Sector Ai
1. Increased the ai's desired construction capacity MAX to 10,000 from 1,000. While also increasing the ratios for desired construction capacity. In test games USA and USSR were at about 2000-3000 capacity and it was being utilized without killing their budget.

Admin Building Changes
1. So I noticed the ai would only selectively utilize the services function in the adm building. I linked the services both security and general to laws, their is still choice just limited choice. If you have no social security, no services. If you have medium you can choose from anything but no. Just forces the ai and the player to actually engage with this mechanic and not abuse it in either direction.

Advanced Mil Equip
1. Evil Crusader alerted me to this bug and it was a quick fix once I figured it out. Advanced mil factories could not make money, it was just impossible with the input to output ratio. Slightly reduced its inputs to where it can make money. This was causing the ai to never build it, therefor never upgrade its military past 3. 

Another Modifier Tweak
1. To compensate for the forced social services which now gives the Soviets an elevated SoL in the early game which often passes the US in the early game until the american economy gets roaring in the late 60s, I reduced the post war SoL boost by 1/2 to +5 but extended it to 20 years instead of 10. I think that like the pop growth change does fit the more extended nature of the post war boom but doesnt give too much to the americans and others. I just don't like seeing the soviets be ahead of the american purely because the american economy just needs time to pass them, cause it does, it always does.