### PR TITLE
 Hello, I managed to resolve the mobilization screen bug with just this small modification.

### DIFF
--- a/common/mobilization_option_groups/00_mobilization_option_groups.txt
+++ b/common/mobilization_option_groups/00_mobilization_option_groups.txt
@@ -1,14 +1,14 @@
-﻿supplies = {
-    icon = "gfx/interface/icons/generic_icons/generic_concept_icon.dds"
-    weight = 5
-}
-
-supplements = {
+supplies = {
     icon = "gfx/interface/icons/generic_icons/generic_concept_icon.dds"
     weight = 5
 }
 
 transport = {
+    icon = "gfx/interface/icons/generic_icons/generic_concept_icon.dds"
+    weight = 5
+}
+
+supplements = {
     icon = "gfx/interface/icons/generic_icons/generic_concept_icon.dds"
     weight = 4
 }


### PR DESCRIPTION
a small change in item properties that resolves the lack of space on the mobilization screen leaving all icons at least partially visible
end result looks like the attached image
<img width="1176" height="517" alt="image" src="https://github.com/user-attachments/assets/413d2ef7-1632-411a-b3dd-6e554cbc8aff" />
