### PR TITLE
Update USA pops

### DIFF
--- a/common/history/pops/05_north_america.txt
+++ b/common/history/pops/05_north_america.txt
@@ -26,11 +26,11 @@
 			create_pop = {
 				culture = anglo_american # 'white' in census
 				religion = catholic
-				size = 136626
+				size = 136926
 			}
 			create_pop = {
 				culture = afro_american
-				size = 1221
+				size = 921
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -48,11 +48,11 @@
 			create_pop = {
 				culture = anglo_american
 				religion = catholic
-				size = 106455 # 532275*0.2 = 106455
+				size = 106655 # 532275*0.2 = 106455
 			}
 			create_pop = {
 				culture = afro_american
-				size = 731
+				size = 531
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -155,12 +155,12 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 9402095
+				size = 9202095
 			}
 			create_pop = {
 				culture = anglo_american
 				religion = catholic
-				size = 2575000
+				size = 2565000
 			}
 			create_pop = {
 				culture = anglo_american
@@ -173,7 +173,7 @@
 			}
 			create_pop = {
 				culture = caribeno
-				size = 20000
+				size = 225000
 			}
 			create_pop = {
 				culture = han
@@ -318,16 +318,16 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 2714152 # 3392690*0.8 = 2714152
+				size = 2677077 # adjusted -37075 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
 				religion = catholic
-				size = 67853 # 3392690*0.02 = 67853.8
+				size = 678538 # 3392690*0.20 = 678538
 			}
 			create_pop = {
 				culture = afro_american
-				size = 28182
+				size = 65257 # 3434575*0.019
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -428,12 +428,12 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 449228
+				size = 533500 # 630000*0.85 = 535500
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
 				religion = catholic
-				size = 79275
+				size = 94500 # 630000*0.15 = 94500
 			}
 			create_pop = {
 				culture = afro_american
@@ -454,7 +454,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1041062 # 1301328*0.8 = 1041062.4
+				size = 1047041 # adjusted +5979 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american
@@ -463,7 +463,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 19234
+				size = 13255 # 1325510*0.01
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -475,7 +475,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1554616
+				size = 1561089 # adjusted +6473 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -484,7 +484,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 73158
+				size = 66685 # 1905299*0.035
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -508,7 +508,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 13598
+				size = 43599
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -620,12 +620,12 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 2467881
+				size = 1164065 # 1293405*0.9 = 1164064.5
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
 				religion = catholic
-				size = 274209
+				size = 129340 # 1293405*0.1 = 129340.5
 			}
 			create_pop = {
 				culture = afro_american
@@ -662,7 +662,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1841143
+				size = 1693220 # adjusted -147923 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -671,7 +671,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 603101
+				size = 751024 # 2771305*0.271
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -713,6 +713,10 @@
 				culture = anglo_american # 'white' in census
 				religion = catholic
 				size = 138012
+			}
+			create_pop = {
+				culture = afro_american
+				size = 530603
 			}
 			create_pop = {
 				culture = anglo_american # 'other' in census
@@ -813,16 +817,16 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1869923 # 2032526*0.92 = 1869923
+				size = 1854625 # adjusted -15298 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
 				religion = catholic
-				size = 162602  # 2032526*0.08 = 162602
+				size = 166602  # 2032526*0.08 = 162602
 			}
 			create_pop = {
 				culture = afro_american
-				size = 145503
+				size = 160801 # 2233351*0.072
 			}
 			create_pop = {
 				culture = cherokee # TODO
@@ -910,7 +914,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 241407
+				size = 242221 # adjusted +814 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -919,7 +923,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 2557
+				size = 1743 # 290529*0.006
 			}
 			create_pop = {
 				culture = anglo_american
@@ -931,7 +935,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1102155
+				size = 1106431 # adjusted +4276 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -940,7 +944,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 20177
+				size = 15901 # 1325089*0.012
 			}
 			create_pop = {
 				culture = anglo_american # TODO
@@ -952,15 +956,15 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 381578 # 630211-248633 = 381578
+				size = 386580 # adjusted +5002 for black pop correction
 			}
 			create_pop = { # https://en.wikipedia.org/wiki/Hispanics_and_Latinos_in_New_Mexico
 				culture = mexican
 				size = 	248633
 			}
 			create_pop = {
-				culture = anglo_american # afro_american
-				size = 8408
+				culture = afro_american
+				size = 3406 # 681187*0.005
 			}
 			create_pop = {
 				culture = navajo # 'other', most likely various different tribes
@@ -972,7 +976,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 446745
+				size = 454729 # adjusted +7984 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -986,7 +990,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 25974
+				size = 17990 # 749587*0.024
 			}
 			create_pop = {
 				culture = navajo # 'other', most likely various different tribes
@@ -1020,7 +1024,7 @@
 			# 25% catholic today
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 119926 # 149908*0.8
+				size = 123268 # adjusted +3342 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -1029,7 +1033,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 4302
+				size = 960 # 160083*0.006
 			}
 			create_pop = {
 				culture = anglo_american # "other"
@@ -1044,7 +1048,7 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 1969021
+				size = 1987817 # adjusted +18796 for black pop correction
 			}
 			create_pop = {
 				culture = anglo_american # 'white' in census
@@ -1053,7 +1057,7 @@
 			}
 			create_pop = {
 				culture = afro_american
-				size = 30691
+				size = 11895 # 2378963*0.005
 			}
 			# very hard to find any details on
 				# https://depts.washington.edu/moving1/Washington.shtml
@@ -1092,12 +1096,12 @@
 		region_state:USA = {
 			create_pop = {
 				culture = anglo_american # 'white' in census
-				size = 7902321 # 9915173-250644-762208 = 8902321
+				size = 7912321 # 9915173-250644-762208 = 8902321
 			}
 			create_pop = {
 				culture = anglo_american
 				religion = catholic
-				size = 1002321
+				size = 1022321
 			}
 			create_pop = {
 				culture = mexican
@@ -1106,7 +1110,7 @@
 			create_pop = {
 				culture = anglo_american
 				religion = jewish
-				size = 250644
+				size = 260644
 			}
 			create_pop = {
 				culture = afro_american
@@ -1153,7 +1157,7 @@
 		region_state:HAW = {
 			create_pop = {
 				culture = hawaiian
-				size = 87400
+				size = 97400
 			}
 			create_pop = {
 				culture = japanese
@@ -1161,7 +1165,7 @@
 			}
 			create_pop = {
 				culture = anglo_american
-				size = 96900
+				size = 106900
 			}
 			create_pop = {
 				culture = anglo_american

--- a/common/history/pops/05_north_america.txt
+++ b/common/history/pops/05_north_america.txt
@@ -1394,7 +1394,7 @@
 		region_state:CAN = {
 			create_pop = {
 				culture = anglo_canadian
-				size = 275000
+				size = 298232
 			}
 			create_pop = {
 				culture = franco_canadian
@@ -1438,7 +1438,7 @@
 			}
 			create_pop = {
 				culture = anglo_canadian # filler
-				size = 230000
+				size = 177752
 			}
 			create_pop = {
 				culture = anglo_canadian # scottish
@@ -1553,7 +1553,7 @@
 		region_state:CAN = {
 			create_pop = {
 				culture = anglo_canadian
-				size = 2100
+				size = 5396
 			}
 			create_pop = {
 				culture = athabaskan
@@ -1580,13 +1580,13 @@
 		# Irish			Catholic	619	
 
 		region_state:CAN = {
-			create_pop = {
+				create_pop = {
 				culture = athabaskan
 				size = 3800
 			}
 			create_pop = {
 				culture = anglo_canadian
-				size = 800
+				size = 2504
 			}
 			create_pop = {
 				culture = anglo_canadian # scottish
@@ -1606,7 +1606,7 @@
 			}
 			create_pop = {
 				culture = anglo_canadian
-				size = 400
+				size = 1300
 			}
 			create_pop = {
 				culture = anglo_canadian # scottish
@@ -1648,7 +1648,7 @@
 			}
 			create_pop = {
 				culture = anglo_canadian # filler
-				size = 240000
+				size = 171917
 			}
 			create_pop = {
 				culture = franco_canadian


### PR DESCRIPTION
Fix US 1950 census pop data: correct Black population percentages across 11 states (WI, FL, OK, NM, WA, AZ, NV, NE, KS, CO, WY), fix SC/KY copy-paste, add missing TN Black pop. Based on 1950 US Census Bureau data